### PR TITLE
Adding ICL support to YuE launcher

### DIFF
--- a/pinokio.js
+++ b/pinokio.js
@@ -63,24 +63,48 @@ module.exports = {
       } else {
         return [{
           icon: "fa-solid fa-power-off",
-          text: "16G VRAM (Full)",
+          text: "16G VRAM Generate",
           href: "start.js",
           params: {
             profile: 1
           }
         }, {
           icon: "fa-solid fa-power-off",
-          text: "12G VRAM (Quantized)",
+          text: "16G VRAM Reference",
+          href: "start.js",
+          params: {
+            profile: 1,
+            icl: true
+          }
+        }, {
+          icon: "fa-solid fa-power-off",
+          text: "12G VRAM Generate",
           href: "start.js",
           params: {
             profile: 3
           }
         }, {
           icon: "fa-solid fa-power-off",
-          text: "10G VRAM (Quantized)",
+          text: "12G VRAM Reference",
+          href: "start.js",
+          params: {
+            profile: 3,
+            icl : true
+          }
+        }, {
+          icon: "fa-solid fa-power-off",
+          text: "10G VRAM Generate",
           href: "start.js",
           params: {
             profile: 4
+          }
+        }, {
+          icon: "fa-solid fa-power-off",
+          text: "10G VRAM Reference",
+          href: "start.js",
+          params: {
+            profile: 4,
+            icl: true
           }
         }, {
           icon: "fa-regular fa-folder-open",

--- a/start.js
+++ b/start.js
@@ -10,7 +10,7 @@ module.exports = {
         },                   // Edit this to customize environment variables (see documentation)
         path: "app/inference",                // Edit this to customize the path to start the shell from
         message: [
-          "python gradio_server.py --profile {{args.profile}} {{args.compile ? '--compile' : ''}}",    // Edit with your custom commands
+          "python gradio_server.py --profile {{args.profile}} {{args.icl ? '--icl' : ''}} {{args.compile ? '--compile' : ''}}",    // Edit with your custom commands
         ],
         on: [{
           // The regular expression pattern to monitor.


### PR DESCRIPTION
Deepbeepmeep's gradio script now has support for loading a reference vocal track and instrumental track. This adds --ICL versions of the 16, 12, and 10GB launchers.