### PR TITLE
readd rtx 50 support

### DIFF
--- a/torch.js
+++ b/torch.js
@@ -1,8 +1,8 @@
 module.exports = {
   run: [
-    // windows nvidia
+    // windows nvidia RTX 50 series
     {
-      "when": "{{platform === 'win32' && gpu === 'nvidia'}}",
+      "when": "{{platform === 'win32' && gpu === 'nvidia' && kernel.gpu_model && / 50.+/.test(kernel.gpu_model) }}",
       "method": "shell.run",
       "params": {
         "venv_python": "{{args && args.venv_python ? args.venv_python : null}}",
@@ -16,9 +16,25 @@ module.exports = {
       },
       "next": null
     },
+    // windows nvidia
+    {
+      "when": "{{platform === 'win32' && gpu === 'nvidia'}}",
+      "method": "shell.run",
+      "params": {
+        "venv_python": "{{args && args.venv_python ? args.venv_python : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": [
+          "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu121 --force-reinstall --no-deps",
+          "uv pip install https://github.com/woct0rdho/triton-windows/releases/download/v3.1.0-windows.post9/triton-3.1.0-cp311-cp311-win_amd64.whl",
+          "uv pip install https://huggingface.co/lldacing/flash-attention-windows-wheel/resolve/main/flash_attn-2.7.0.post2%2Bcu124torch2.5.1cxx11abiFALSE-cp311-cp311-win_amd64.whl"
+        ]
+      },
+      "next": null
+    },
     // linux nvidia
     {
-      "when": "{{platform === 'linux' && gpu === 'nvidia'}}",
+      "when": "{{platform === 'linux' && gpu === 'nvidia' && kernel.gpu_model && / 50.+/.test(kernel.gpu_model) }}",
       "method": "shell.run",
       "params": {
         "venv_python": "{{args && args.venv_python ? args.venv_python : null}}",
@@ -31,6 +47,21 @@ module.exports = {
         ]
       },
       "next": null
+    },
+    // linux nvidia
+    {
+      "when": "{{platform === 'linux' && gpu === 'nvidia'}}",
+      "method": "shell.run",
+      "params": {
+        "venv_python": "{{args && args.venv_python ? args.venv_python : null}}",
+        "venv": "{{args && args.venv ? args.venv : null}}",
+        "path": "{{args && args.path ? args.path : '.'}}",
+        "message": [
+          "uv pip install torch==2.5.1 torchvision==0.20.1 torchaudio==2.5.1 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu124 --force-reinstall --no-deps",
+          "{{args && args.triton ? 'uv pip install triton' : ''}}",
+          "uv pip install https://github.com/mjun0812/flash-attention-prebuild-wheels/releases/download/v0.4.11/flash_attn-2.8.3+cu124torch2.5-cp311-cp311-linux_x86_64.whl"
+        ]
+      }
     },
     // linux rocm (amd)
     {


### PR DESCRIPTION
non 50 series nvidia need their own flash attention wheel since flash attention 2.7.4 post fails on rtx 30 series and below